### PR TITLE
fix: zsh-autosuggestions 链接不能正常跳转

### DIFF
--- a/docs/guide/Shell.md
+++ b/docs/guide/Shell.md
@@ -138,7 +138,7 @@ $ gb // 等价于git branch
 
 #### zsh-autosuggestions
 
-它能够根据你的命令历史记录即时提示，个人对它的喜爱程度仅次于 autojump。BTW，每次用同事的电脑我都会想吐槽，还不是因为他没安装 [zsh-autosuggestions]((https://github.com/zsh-users/zsh-autosuggestions/blob/master/INSTALL.md)) 😏
+它能够根据你的命令历史记录即时提示，个人对它的喜爱程度仅次于 autojump。BTW，每次用同事的电脑我都会想吐槽，还不是因为他没安装 [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions/blob/master/INSTALL.md) 😏
 
 ##### Preview
 


### PR DESCRIPTION
zsh-autosuggestions 链接不能正常跳转（多了个括号）